### PR TITLE
Switch to construted inventory for the kubeconfig copy

### DIFF
--- a/roles/ec2instances/files/tf/.terraform.lock.hcl
+++ b/roles/ec2instances/files/tf/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.31.0"
+  constraints = ">= 3.72.0, >= 4.21.0"
+  hashes = [
+    "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
+    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
+    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
+    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
+    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
+    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
+    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
+    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
+    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
+    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
+    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
+    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
+    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
+    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = ">= 3.4.0"
+  hashes = [
+    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/roles/ec2instances/files/tf/main.tf
+++ b/roles/ec2instances/files/tf/main.tf
@@ -1,15 +1,19 @@
 locals {
-  suffix = "${replace(terraform.workspace, "_", "-")}"
+  suffix    = replace(terraform.workspace, "_", "-")
+  workspace = terraform.workspace
 
-  region = var.aws_region
-  key_name = var.key_name
-  instance_type = var.instance_type
-  ami = var.ami
+  region         = var.aws_region
+  key_name       = var.key_name
+  instance_type  = var.instance_type
+  ami            = var.ami
   instance_count = var.instance_count
 
   tags = {
-    GithubRepo = "operator-workshop"
-    GithubOrg = "opdev"
+    GithubRepo  = "operator-workshop"
+    GithubOrg   = "opdev"
+    Terraform   = "true"
+    Environment = "prod"
+    Workshop    = terraform.workspace
   }
 }
 
@@ -21,21 +25,18 @@ module "key_pair" {
 }
 
 module "ec2_instance" {
-  source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 3.0"
+  source = "terraform-aws-modules/ec2-instance/aws"
 
   count = local.instance_count
 
   name = "instance-${local.suffix}-${format("%02d", count.index)}"
 
-  ami                    = lookup(local.ami,local.region)
-  instance_type          = local.instance_type
-  key_name               = module.key_pair.key_pair_name
+  ami           = lookup(local.ami, local.region)
+  instance_type = local.instance_type
+  key_name      = module.key_pair.key_pair_name
 
-  tags = {
-    Terraform   = "true"
-    Environment = "prod"
-    Name  = "Instance-${local.suffix}-${format("%02d", count.index)}"
-    Workshop = local.suffix
-  }
+  tags = merge(local.tags, {
+    Name = "Instance-${local.suffix}-${format("%02d", count.index)}"
+    Sno  = "sno-lab-${local.workspace}-${format("%02x", count.index)}"
+  })
 }

--- a/roles/ec2instances/tasks/create.yml
+++ b/roles/ec2instances/tasks/create.yml
@@ -9,6 +9,18 @@
     dest: "/tmp/aws.pem"
     mode: "0600"
 
+- name: Also write keyfile to k8s
+  kubernetes.core.k8s:
+    namespace: "{{ ec2instances_kube_namespace }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "ec2-key-{{ ec2instances_workshop_name }}"
+      type: Opaque
+      data:
+        aws.pem: "{{ terraform_outputs.outputs.private_key_pem.value | ansible.builtin.b64encode }}"
+
 - name: Add hosts to inventory
   ansible.builtin.add_host:
     name: "{{ item.public_dns }}"

--- a/roles/ec2instances/tasks/main.yml
+++ b/roles/ec2instances/tasks/main.yml
@@ -17,7 +17,8 @@
     KUBE_IN_CLUSTER_CONFIG: "true"
     TF_VAR_workshop_name: "{{ ec2instances_workshop_name }}"
     TF_VAR_instance_count: "{{ ec2instances_instance_count }}"
-    # TF_VAR_key_name: lay-key-{{ workshop_name }}
+    TF_VAR_key_name: lab-key-{{ workshop_name }}
+    TF_VAR_instance_type: "t2.micro"
   register: terraform_outputs
 
 - name: Additional setup upon create

--- a/roles/ec2userdata/tasks/main.yml
+++ b/roles/ec2userdata/tasks/main.yml
@@ -125,6 +125,8 @@
   ansible.builtin.copy:
     src: "{{ role_path }}/files/{{ item.path }}/{{ item.filename }}"
     dest: /tmp/{{ item.filename }}
+    owner: ec2-user
+    group: ec2-user
     mode: '0644'
   loop:
     - { path: go-operator-memcached, filename: memcached_types.go }
@@ -143,6 +145,8 @@
   ansible.builtin.file:
     path: /home/ec2-user/tutorial
     state: directory
+    owner: ec2-user
+    group: ec2-user
     mode: '0755'
 
 - name: Setup ansible lab exercise assets
@@ -150,11 +154,15 @@
     cmd: ansible-galaxy init example-role --offline
     chdir: /home/ec2-user/tutorial
     creates: /home/ec2-user/tutorial/example-role/README.md
+  become: true
+  become_user: ec2-user
 
 - name: Create .kube dir
   ansible.builtin.file:
     path: /home/ec2-user/.kube
     state: directory
+    owner: ec2-user
+    group: ec2-user
     mode: '0755'
 
 - name: Copy tutorial assets
@@ -162,6 +170,8 @@
     src: "{{ role_path }}/files/{{ item.path }}/{{ item.filename }}"
     dest: /tmp/{{ item.filename }}
     mode: '0644'
+    owner: ec2-user
+    group: ec2-user
   loop:
     - { path: tutorial, filename: myhosts }
     - { path: tutorial, filename: nginx-deployment.yml }

--- a/roles/kubeconfig/tasks/k8s.yml
+++ b/roles/kubeconfig/tasks/k8s.yml
@@ -1,0 +1,67 @@
+---
+- name: Get ClusterClaim
+  kubernetes.core.k8s_info:
+    kind: ClusterClaim
+    api_version: hive.openshift.io/v1
+    name: "{{ kubeconfig_sno_name }}"
+    namespace: "workshops"
+  register: claim_results
+  delegate_to: localhost
+
+- name: Get ClusterDeployment
+  kubernetes.core.k8s_info:
+    kind: ClusterDeployment
+    api_version: hive.openshift.io/v1
+    name: "{{ claim_results.resources[0].spec.namespace }}"
+    namespace: "{{ claim_results.resources[0].spec.namespace }}"
+  register: deployment_results
+  delegate_to: localhost
+
+- name: Fetch install artifact from k8s
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ deployment_results.resources[0].spec.clusterMetadata.adminKubeconfigSecretRef.name }}"
+    namespace: "{{ claim_results.resources[0].spec.namespace }}"
+  register: kubeconfig_results
+  delegate_to: localhost
+
+- name: Decode the data
+  ansible.builtin.set_fact:
+    kubeconfig: "{{ kubeconfig_results.resources[0].data.kubeconfig | ansible.builtin.b64decode }}"
+
+- name: Ensure .kube dir 
+  ansible.builtin.file:
+    dest: /home/ec2-user/.kube
+    mode: "0700"
+    owner: "ec2-user"
+    group: "ec2-user"
+
+- name: Write it out
+  ansible.builtin.copy:
+    content: "{{ kubeconfig }}"
+    dest: /home/ec2-user/.kube/config
+    mode: "0600"
+    owner: "ec2-user"
+    group: "ec2-user"
+
+- name: Fetch the kubeadmin password
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ deployment_results.resources[0].spec.clusterMetadata.adminPasswordSecretRef.name }}"
+    namespace: "{{ claim_results.resources[0].spec.namespace }}"
+  register: kubeadmin_results
+  delegate_to: localhost
+
+- name: Decode the data
+  ansible.builtin.set_fact:
+    kubeadmin_password: "{{ kubeadmin_results.resources[0].data.password | ansible.builtin.b64decode }}"
+
+- name: Write it out
+  ansible.builtin.copy:
+    content: "{{ kubeadmin_password }}"
+    dest: /home/ec2-user/kubeadmin-password
+    mode: "0600"
+    owner: "ec2-user"
+    group: "ec2-user"

--- a/roles/kubeconfig/tasks/main.yml
+++ b/roles/kubeconfig/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 - name: Fetch install artifact from S3
   amazon.aws.s3_object:
-    bucket: "{{ bucket_name }}"
-    object: "/{{ sno_name }}/kubeconfig"
+    bucket: "{{ kubeconfig_bucket_name }}"
+    object: "/{{ kubeconfig_sno_name }}/kubeconfig"
     dest: "/home/ec2-user/.kube/config"
     mode: get
+  when: kubeconfig_source == "s3"
+
+- name: Get kubeconfig from k8s secret
+  ansible.builtin.include_tasks:
+    file: k8s.yml
+  when: kubeconfig_source == "k8s"
+

--- a/roles/sno/tasks/create.yml
+++ b/roles/sno/tasks/create.yml
@@ -26,6 +26,6 @@
     workshop_name: "{{ sno_workshop_name }}"
     claim_query: "resources[*].status.conditions[?type=='ClusterRunning'].status[]"
   register: claim_results
-  until: claim_results|community.general.json_query(claim_query)|unique
+  until: claim_results | community.general.json_query(claim_query) | unique | reject("equalto", "True") | length == 0
   retries: 60
   delay: 60

--- a/roles/sno/templates/install-config.yaml.j2
+++ b/roles/sno/templates/install-config.yaml.j2
@@ -8,7 +8,7 @@ controlPlane:
     aws:
       rootVolume:
         size: 120
-      type: m5.xlarge 
+      type: m6i.2xlarge 
   replicas: 1
 compute:
 - hyperthreading: Enabled
@@ -17,7 +17,7 @@ compute:
     aws:
       rootVolume:
         size: 120
-      type: m5.xlarge
+      type: m6i.2xlarge
   replicas: 0
 metadata:
   creationTimestamp: null

--- a/sno.yml
+++ b/sno.yml
@@ -14,10 +14,20 @@
         sno_instance_count: "{{ workshop_instances }}"
         sno_workshops_namespace: "{{ workshops_namespace }}"
         sno_region: "{{ sno_workshop_region }}"
+  post_tasks:
+    - name: Write keyfile to disk
+      ansible.builtin.copy:
+        content: "{{ private_key_pem }}"
+        dest: "/tmp/aws.pem"
+        mode: "0600"
+      when: not teardown
+
 - name: Copy kubeconfig to each ec2 instance
-  hosts: ec2instances
+  hosts: ec2instances_{{ workshop_name }}
   roles:
     - role: kubeconfig
       vars:
-        kubeconfig_bucket_name: "exe-workshop-{{ workshop_name }}"
+        kubeconfig_source: "k8s"
+        kubeconfig_sno_name: "{{ tags['Sno'] }}"
+        kubeconfig_workshop_name: "{{ workshop_name }}"
       when: not teardown


### PR DESCRIPTION
The constructed inventory will just give the hosts that belong to the given workshop. This will generate the proper inventory.