### PR TITLE
The terraform ec2instances works out of cluster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-kubernetes >= 25
-
+ansible-builder==3.0.0
+ansible-lint==6.21.1
+ansible-navigator==3.5.0
+ansible-runner==2.3.4
+boto3==1.28.49
+botocore==1.31.49
+kubernetes>=28.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,5 @@
 collections:
   - kubernetes.core
   - amazon.aws
+  - cloud.terraform
   - community.general

--- a/roles/ec2instances/defaults/main.yml
+++ b/roles/ec2instances/defaults/main.yml
@@ -3,3 +3,8 @@ ec2instances_destroy: false
 ec2instances_workshop_name: default
 ec2instances_kube_namespace: workshops
 ec2instances_region: us-east-1
+ec2instances_terraform_force_init: true
+ec2instances_terraform_init_reconfigure: true
+
+# Since this gets passed to terraform, it must be a string. Otherwise, terraform complains.
+ec2instances_kube_in_cluster_config: "true"

--- a/roles/ec2instances/files/tf/.terraform.lock.hcl
+++ b/roles/ec2instances/files/tf/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.31.0"
-  constraints = ">= 3.72.0, >= 4.21.0"
+  constraints = ">= 4.21.0, >= 4.66.0"
   hashes = [
     "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
+    "h1:WwgMbMOhZblxZTdjHeJf9XB2/hcSHHmpuywLxuTWYw0=",
     "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
     "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
     "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.5"
   constraints = ">= 3.4.0"
   hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
     "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
     "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
     "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",

--- a/roles/ec2instances/tasks/main.yml
+++ b/roles/ec2instances/tasks/main.yml
@@ -1,24 +1,25 @@
 ---
 - name: Deploy or destroy the EC2 instances
-  community.general.terraform:
+  cloud.terraform.terraform:
     state: "{{ ec2instances_destroy | ternary('absent', 'present') }}"
     project_path: "{{ role_path }}/files/tf/"
     workspace: "{{ ec2instances_workshop_name }}"
     purge_workspace: "{{ ec2instances_destroy }}"
-    force_init: true
-    init_reconfigure: true
+    force_init: "{{ ec2instances_terraform_force_init }}"
+    init_reconfigure: "{{ ec2instances_terraform_init_reconfigure }}"
     complex_vars: true
     variables:
       aws_region: "{{ ec2instances_region }}"
-  environment:
-    KUBE_TOKEN: "{{ ec2instances_kube_token }}"
-    KUBE_HOST: "{{ ec2instances_kube_host }}"
-    KUBE_NAMESPACE: "{{ ec2instances_kube_namespace }}"
-    KUBE_IN_CLUSTER_CONFIG: "true"
-    TF_VAR_workshop_name: "{{ ec2instances_workshop_name }}"
-    TF_VAR_instance_count: "{{ ec2instances_instance_count }}"
-    TF_VAR_key_name: lab-key-{{ workshop_name }}
-    TF_VAR_instance_type: "t2.micro"
+      instance_count: "{{ ec2instances_instance_count }}"
+      key_name: "lab-key-{{ ec2instances_workshop_name }}"
+      instance_type: "t2.micro"
+    backend_config:
+      token: "{{ lookup('ansible.builtin.env', 'KUBE_TOKEN', default=omit) }}"
+      host: "{{ lookup('ansible.builtin.env', 'KUBE_HOST', default=omit) }}"
+      in_cluster_config: "{{ lookup('ansible.builtin.env', 'KUBE_IN_CLUSTER_CONFIG', default=omit) }}"
+      config_path: "{{ lookup('ansible.builtin.env', 'KUBE_CONFIG_PATH', default=omit) }}"
+      username: "{{ lookup('ansible.builtin.env', 'KUBE_USERNAME', default=omit) }}"
+      namespace: "{{ ec2instances_kube_namespace }}"
   register: terraform_outputs
 
 - name: Additional setup upon create


### PR DESCRIPTION
The terraform k8s backend would only work within a cluster. This now allows it to be used out of cluster in order to facilitate testing without running without aap.

Fixes #13